### PR TITLE
Add per-session schema cache and switch EngineFactory to Arc

### DIFF
--- a/swanlake-core/src/maintenance/mod.rs
+++ b/swanlake-core/src/maintenance/mod.rs
@@ -4,7 +4,7 @@
 //! metadata (`ducklake_checkpoints` table) and advisory locks.
 
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
@@ -62,18 +62,18 @@ impl CheckpointConfig {
 /// Handles background checkpointing lifecycle.
 pub struct CheckpointService {
     cfg: CheckpointConfig,
-    factory: Arc<Mutex<EngineFactory>>,
+    factory: Arc<EngineFactory>,
 }
 
 impl CheckpointService {
-    pub fn new(cfg: CheckpointConfig, factory: Arc<Mutex<EngineFactory>>) -> Self {
+    pub fn new(cfg: CheckpointConfig, factory: Arc<EngineFactory>) -> Self {
         Self { cfg, factory }
     }
 
     /// Spawn the checkpoint loop if there is work configured.
     pub async fn spawn_from_config(
         config: &ServerConfig,
-        factory: Arc<Mutex<EngineFactory>>,
+        factory: Arc<EngineFactory>,
     ) -> Result<()> {
         let Some(cfg) = CheckpointConfig::from_server_config(config) else {
             debug!("no checkpoint databases configured; skipping checkpoint task");
@@ -170,14 +170,9 @@ impl CheckpointService {
         let db = db_name.to_string();
         let factory = self.factory.clone();
         tokio::task::spawn_blocking(move || {
-            let conn = {
-                let guard = factory
-                    .lock()
-                    .map_err(|_| anyhow!("EngineFactory lock poisoned"))?;
-                guard
-                    .create_connection()
-                    .map_err(|e| anyhow!(e.to_string()))?
-            };
+            let conn = factory
+                .create_connection()
+                .map_err(|e| anyhow!(e.to_string()))?;
             let sql = format!("USE {}; CHECKPOINT;", db);
             conn.execute_batch(&sql)
                 .map_err(|e| anyhow!(e.to_string()))

--- a/swanlake-server/src/main.rs
+++ b/swanlake-server/src/main.rs
@@ -21,9 +21,8 @@ async fn main() -> Result<()> {
         .bind_addr()
         .context("failed to resolve bind address")?;
 
-    let factory = Arc::new(std::sync::Mutex::new(
-        EngineFactory::new(&config).context("failed to initialize engine factory")?,
-    ));
+    let factory =
+        Arc::new(EngineFactory::new(&config).context("failed to initialize engine factory")?);
 
     // Spawn DuckLake checkpoint maintenance task
     CheckpointService::spawn_from_config(&config, factory.clone())


### PR DESCRIPTION
- Introduce an LRU schema cache to Session for faster schema_for_query.
- Invalidate schema cache on DDL or catalog-changing statements.
- Replace Arc<Mutex<EngineFactory>> with Arc<EngineFactory> throughout.
- Enforce max_sessions via a semaphore in SessionRegistry.
- SessionRegistry now holds session permits to prevent session leaks.
- EngineFactory connection creation moved to spawn_blocking to avoid blocking async tasks.