### PR TITLE
fix: address critical bugs #126 #127 #128 #129

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ __marimo__
 recipe.json
 __pycache__/
 *.profraw
+.superpowers-skills
+.rules

--- a/swanlake-core/src/engine/connection.rs
+++ b/swanlake-core/src/engine/connection.rs
@@ -13,7 +13,7 @@ use duckdb::{Arrow, Statement};
 use tracing::{debug, info, instrument};
 
 use crate::error::ServerError;
-use crate::util::quote_identifier;
+use crate::util::{quote_identifier, quote_qualified_name};
 
 use crate::types::duckdb_type_to_arrow;
 
@@ -203,7 +203,7 @@ impl DuckDbConnection {
             .map_err(|_| ServerError::Internal("connection mutex poisoned".to_string()))?;
 
         // Use DESC to get table schema without preparing parameters
-        let desc_query = format!("DESC SELECT * FROM {}", quote_identifier(table_name));
+        let desc_query = format!("DESC SELECT * FROM {}", quote_qualified_name(table_name));
         let mut stmt = conn.prepare(&desc_query).map_err(ServerError::DuckDb)?;
         let rows = stmt
             .query_map([], |row| {

--- a/swanlake-core/src/engine/connection.rs
+++ b/swanlake-core/src/engine/connection.rs
@@ -13,6 +13,7 @@ use duckdb::{Arrow, Statement};
 use tracing::{debug, info, instrument};
 
 use crate::error::ServerError;
+use crate::util::quote_identifier;
 
 use crate::types::duckdb_type_to_arrow;
 
@@ -178,7 +179,7 @@ impl DuckDbConnection {
             .conn
             .lock()
             .map_err(|_| ServerError::Internal("connection mutex poisoned".to_string()))?;
-        conn.execute(&format!("USE {catalog_name};"), [])?;
+        conn.execute(&format!("USE {};", quote_identifier(catalog_name)), [])?;
         let mut appender = conn.appender(table_name)?;
         for batch in batches {
             appender.append_record_batch(batch)?;
@@ -202,7 +203,7 @@ impl DuckDbConnection {
             .map_err(|_| ServerError::Internal("connection mutex poisoned".to_string()))?;
 
         // Use DESC to get table schema without preparing parameters
-        let desc_query = format!("DESC SELECT * FROM {table_name}");
+        let desc_query = format!("DESC SELECT * FROM {}", quote_identifier(table_name));
         let mut stmt = conn.prepare(&desc_query).map_err(ServerError::DuckDb)?;
         let rows = stmt
             .query_map([], |row| {

--- a/swanlake-core/src/lib.rs
+++ b/swanlake-core/src/lib.rs
@@ -17,3 +17,4 @@ pub mod service;
 pub mod session;
 pub mod sql;
 pub mod types;
+pub mod util;

--- a/swanlake-core/src/maintenance/mod.rs
+++ b/swanlake-core/src/maintenance/mod.rs
@@ -14,6 +14,7 @@ use tracing::{debug, info, warn};
 
 use crate::config::ServerConfig;
 use crate::engine::{DuckDbConnection, EngineFactory};
+use crate::util::quote_identifier;
 
 mod lock;
 mod postgres;
@@ -203,7 +204,7 @@ impl CheckpointService {
                 *guard = Some(conn);
             }
 
-            let sql = format!("USE {db}; CHECKPOINT;");
+            let sql = format!("USE {}; CHECKPOINT;", quote_identifier(&db));
             let exec = if let Some(conn) = guard.as_ref() {
                 conn.execute_batch(&sql).map_err(|e| anyhow!(e.to_string()))
             } else {

--- a/swanlake-core/src/service/execute.rs
+++ b/swanlake-core/src/service/execute.rs
@@ -66,8 +66,9 @@ impl SwanFlightSqlService {
                 warn!(
                     handle = %handle,
                     %err,
-                    "failed to close ephemeral prepared statement"
+                    "failed to close ephemeral prepared statement; force-removing handle"
                 );
+                session.remove_prepared_statement(handle);
             }
         }
 
@@ -155,8 +156,9 @@ impl SwanFlightSqlService {
                 warn!(
                     handle = %handle,
                     %err,
-                    "failed to close ephemeral prepared statement"
+                    "failed to close ephemeral prepared statement; force-removing handle"
                 );
+                session.remove_prepared_statement(handle);
             }
         }
 

--- a/swanlake-core/src/session/mod.rs
+++ b/swanlake-core/src/session/mod.rs
@@ -684,3 +684,276 @@ impl Session {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::{anyhow, Result};
+    use duckdb::Connection;
+
+    /// Helper: create a `Session` backed by a real in-memory DuckDB connection.
+    fn test_session() -> Result<Session> {
+        let raw = Connection::open_in_memory().map_err(|e| anyhow!("open_in_memory: {e}"))?;
+        let conn = DuckDbConnection::new(raw);
+        Ok(Session::new_with_id(
+            SessionId::from_string("test:session".into()),
+            conn,
+        ))
+    }
+
+    /// Helper: create a prepared statement and return its handle.
+    fn create_test_handle(session: &Session) -> Result<StatementHandle> {
+        session
+            .create_prepared_statement("SELECT 1".into(), true, PreparedStatementOptions::new())
+            .map_err(|e| anyhow!("create_prepared_statement: {e}"))
+    }
+
+    // ---------------------------------------------------------------
+    // remove_prepared_statement
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn remove_prepared_statement_clears_entry_from_map() -> Result<()> {
+        let session = test_session()?;
+        let handle = create_test_handle(&session)?;
+
+        // Sanity: handle exists before removal.
+        assert!(session.get_prepared_statement_meta(handle).is_ok());
+
+        session.remove_prepared_statement(handle);
+
+        // After force-remove the handle must be gone.
+        assert!(matches!(
+            session.get_prepared_statement_meta(handle),
+            Err(ServerError::PreparedStatementNotFound)
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn remove_prepared_statement_clears_last_handle_when_matching() -> Result<()> {
+        let session = test_session()?;
+        let handle = create_test_handle(&session)?;
+
+        // The just-created handle should be the last handle.
+        assert_eq!(session.last_prepared_statement_handle(), Some(handle));
+
+        session.remove_prepared_statement(handle);
+
+        // last_handle should be cleared.
+        assert_eq!(session.last_prepared_statement_handle(), None);
+        Ok(())
+    }
+
+    #[test]
+    fn remove_prepared_statement_is_idempotent() -> Result<()> {
+        let session = test_session()?;
+        let handle = create_test_handle(&session)?;
+
+        session.remove_prepared_statement(handle);
+        // Calling again should not panic or error.
+        session.remove_prepared_statement(handle);
+
+        assert!(matches!(
+            session.get_prepared_statement_meta(handle),
+            Err(ServerError::PreparedStatementNotFound)
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn remove_prepared_statement_does_not_affect_other_handles() -> Result<()> {
+        let session = test_session()?;
+        let h1 = create_test_handle(&session)?;
+        let h2 = session
+            .create_prepared_statement("SELECT 2".into(), true, PreparedStatementOptions::new())
+            .map_err(|e| anyhow!("create h2: {e}"))?;
+
+        session.remove_prepared_statement(h1);
+
+        // h2 should still be accessible.
+        assert!(session.get_prepared_statement_meta(h2).is_ok());
+        // h1 is gone.
+        assert!(matches!(
+            session.get_prepared_statement_meta(h1),
+            Err(ServerError::PreparedStatementNotFound)
+        ));
+        Ok(())
+    }
+
+    // ---------------------------------------------------------------
+    // recover_from_transaction_abort — success path
+    // ---------------------------------------------------------------
+
+    /// Build a ServerError that triggers is_transaction_abort_error.
+    fn make_abort_error() -> ServerError {
+        ServerError::DuckDb(duckdb::Error::DuckDBFailure(
+            duckdb::ffi::Error {
+                code: duckdb::ErrorCode::Unknown,
+                extended_code: 0,
+            },
+            Some("Current transaction is aborted".into()),
+        ))
+    }
+
+    #[test]
+    fn recover_clears_transactions_on_abort_error() -> Result<()> {
+        let session = test_session()?;
+
+        // Start a real transaction so DuckDB is in a transaction state.
+        session
+            .connection
+            .execute_batch("BEGIN TRANSACTION")
+            .map_err(|e| anyhow!("BEGIN: {e}"))?;
+
+        // Simulate Rust-side tracking: insert a transaction ID.
+        let tx_id = session.transaction_id_gen.next();
+        {
+            let mut txs = session
+                .transactions
+                .lock()
+                .map_err(|e| anyhow!("lock: {e}"))?;
+            txs.insert(tx_id);
+        }
+
+        session.recover_from_transaction_abort(&make_abort_error());
+
+        // transactions set should be cleared.
+        let txs = session
+            .transactions
+            .lock()
+            .map_err(|e| anyhow!("lock: {e}"))?;
+        assert!(
+            txs.is_empty(),
+            "transactions should be cleared after recovery"
+        );
+
+        // tx_id should appear in aborted_transactions.
+        let aborted = session
+            .aborted_transactions
+            .lock()
+            .map_err(|e| anyhow!("lock: {e}"))?;
+        assert!(
+            aborted.contains(&tx_id),
+            "aborted_transactions should contain the cleared tx_id"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn recover_is_noop_for_non_abort_errors() -> Result<()> {
+        let session = test_session()?;
+
+        // Add a transaction to the set.
+        let tx_id = session.transaction_id_gen.next();
+        {
+            let mut txs = session
+                .transactions
+                .lock()
+                .map_err(|e| anyhow!("lock: {e}"))?;
+            txs.insert(tx_id);
+        }
+
+        // A non-abort error should not trigger recovery.
+        let err = ServerError::Internal("some random error".into());
+        session.recover_from_transaction_abort(&err);
+
+        let txs = session
+            .transactions
+            .lock()
+            .map_err(|e| anyhow!("lock: {e}"))?;
+        assert!(
+            txs.contains(&tx_id),
+            "transactions should be untouched for non-abort errors"
+        );
+        Ok(())
+    }
+
+    // ---------------------------------------------------------------
+    // recover_from_transaction_abort — multiple transactions path
+    //
+    // Verifies the key invariant: all tracked tx_ids move to
+    // aborted_transactions regardless of how many are tracked.
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn recover_clears_all_transactions_and_moves_to_aborted() -> Result<()> {
+        let session = test_session()?;
+
+        // Insert multiple tracked transactions.
+        let tx_id = session.transaction_id_gen.next();
+        let tx_id2 = session.transaction_id_gen.next();
+        {
+            let mut txs = session
+                .transactions
+                .lock()
+                .map_err(|e| anyhow!("lock: {e}"))?;
+            txs.insert(tx_id);
+            txs.insert(tx_id2);
+        }
+
+        // Start a real transaction so DuckDB has something to ROLLBACK.
+        session
+            .connection
+            .execute_batch("BEGIN TRANSACTION")
+            .map_err(|e| anyhow!("BEGIN: {e}"))?;
+
+        session.recover_from_transaction_abort(&make_abort_error());
+
+        // Both transaction IDs should be cleared from transactions.
+        let txs = session
+            .transactions
+            .lock()
+            .map_err(|e| anyhow!("lock: {e}"))?;
+        assert!(txs.is_empty(), "all transactions should be cleared");
+
+        // Both should be in aborted set.
+        let aborted = session
+            .aborted_transactions
+            .lock()
+            .map_err(|e| anyhow!("lock: {e}"))?;
+        assert!(aborted.contains(&tx_id), "tx_id should be in aborted set");
+        assert!(aborted.contains(&tx_id2), "tx_id2 should be in aborted set");
+        Ok(())
+    }
+
+    // ---------------------------------------------------------------
+    // transaction_absent — verifies aborted transaction detection
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn transaction_absent_returns_aborted_for_known_aborted_tx() -> Result<()> {
+        let session = test_session()?;
+        let tx_id = session.transaction_id_gen.next();
+
+        // Pre-populate aborted set (as recovery would).
+        {
+            let mut aborted = session
+                .aborted_transactions
+                .lock()
+                .map_err(|e| anyhow!("lock: {e}"))?;
+            aborted.insert(tx_id);
+        }
+
+        let result = session.transaction_absent(tx_id);
+        assert!(matches!(result, Err(ServerError::TransactionAborted)));
+
+        // Should be removed from aborted set after detection.
+        let aborted = session
+            .aborted_transactions
+            .lock()
+            .map_err(|e| anyhow!("lock: {e}"))?;
+        assert!(!aborted.contains(&tx_id));
+        Ok(())
+    }
+
+    #[test]
+    fn transaction_absent_returns_ok_for_unknown_tx() -> Result<()> {
+        let session = test_session()?;
+        let tx_id = session.transaction_id_gen.next();
+
+        let result = session.transaction_absent(tx_id);
+        assert!(result.is_ok());
+        Ok(())
+    }
+}

--- a/swanlake-core/src/session/mod.rs
+++ b/swanlake-core/src/session/mod.rs
@@ -17,7 +17,7 @@ use std::time::{Duration, Instant};
 
 use arrow_schema::Schema;
 use duckdb::types::Value;
-use tracing::{debug, info, instrument, warn};
+use tracing::{debug, error, info, instrument, warn};
 
 use crate::engine::{DuckDbConnection, QueryResult};
 use crate::error::ServerError;
@@ -245,7 +245,28 @@ impl Session {
                 );
             }
             Err(rollback_err) => {
-                warn!(error = %rollback_err, "failed to rollback aborted transaction");
+                let mut txs = self
+                    .transactions
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                let ids: Vec<_> = txs.iter().copied().collect();
+                txs.clear();
+                drop(txs);
+
+                let mut aborted = self
+                    .aborted_transactions
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                for id in ids {
+                    aborted.insert(id);
+                }
+                drop(aborted);
+
+                error!(
+                    error = %rollback_err,
+                    "failed to rollback aborted transaction; \
+                     cleared Rust-side transaction tracking but session may be in an inconsistent state"
+                );
             }
         }
     }
@@ -558,6 +579,25 @@ impl Session {
         }
         debug!(handle = %handle, "closed prepared statement");
         Ok(())
+    }
+
+    /// Unconditionally remove a prepared statement handle from the session map.
+    /// Unlike [`close_prepared_statement`], this never returns an error — it is
+    /// a best-effort cleanup used when a prior close attempt has already failed.
+    pub fn remove_prepared_statement(&self, handle: StatementHandle) {
+        let mut prepared = self
+            .prepared_statements
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        prepared.remove(&handle);
+        let mut last_handle = self
+            .last_prepared_statement_handle
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if last_handle.as_ref() == Some(&handle) {
+            *last_handle = None;
+        }
+        debug!(handle = %handle, "force-removed prepared statement from session map");
     }
 
     pub fn last_prepared_statement_handle(&self) -> Option<StatementHandle> {

--- a/swanlake-core/src/session/registry.rs
+++ b/swanlake-core/src/session/registry.rs
@@ -189,6 +189,23 @@ impl SessionRegistry {
                 ServerError::MaxSessionsReached
             })?;
 
+        // Re-check under write lock before creating the expensive DuckDB connection
+        // to prevent TOCTOU race where two concurrent requests for the same session_id
+        // both pass the initial read-lock check and create duplicate connections.
+        {
+            let inner = self
+                .inner
+                .read()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if let Some(entry) = inner.sessions.get(session_id) {
+                debug!(
+                    session_id = %session_id,
+                    "session appeared after permit acquisition, reusing"
+                );
+                return Ok(entry.session.clone());
+            }
+        }
+
         // Create new connection in spawn_blocking to avoid blocking async runtime
         // (DuckDB connection creation involves I/O: loading extensions, init SQL, etc.)
         let factory = self.factory.clone();
@@ -199,7 +216,7 @@ impl SessionRegistry {
         // Create session with the specified ID
         let session = Arc::new(Session::new_with_id(session_id.clone(), connection));
 
-        // Register session
+        // Register session under write lock, with a final check for races
         {
             let mut inner = self
                 .inner

--- a/swanlake-core/src/util.rs
+++ b/swanlake-core/src/util.rs
@@ -28,7 +28,7 @@ pub fn quote_identifier(name: &str) -> String {
 /// ```
 pub fn quote_qualified_name(name: &str) -> String {
     name.split('.')
-        .map(|part| quote_identifier(part))
+        .map(quote_identifier)
         .collect::<Vec<_>>()
         .join(".")
 }

--- a/swanlake-core/src/util.rs
+++ b/swanlake-core/src/util.rs
@@ -1,0 +1,44 @@
+//! Shared utility helpers.
+
+/// Wraps a SQL identifier in double quotes, escaping any embedded double quotes
+/// by doubling them (standard SQL identifier quoting).
+///
+/// # Examples
+///
+/// ```
+/// # use swanlake_core::util::quote_identifier;
+/// assert_eq!(quote_identifier("my_table"), r#""my_table""#);
+/// assert_eq!(quote_identifier(r#"has"quote"#), r#""has""quote""#);
+/// ```
+pub fn quote_identifier(name: &str) -> String {
+    let escaped = name.replace('"', r#""""#);
+    format!(r#""{escaped}""#)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_identifier() {
+        assert_eq!(quote_identifier("users"), r#""users""#);
+    }
+
+    #[test]
+    fn identifier_with_embedded_quotes() {
+        assert_eq!(quote_identifier(r#"my"table"#), r#""my""table""#);
+    }
+
+    #[test]
+    fn empty_identifier() {
+        assert_eq!(quote_identifier(""), r#""""#);
+    }
+
+    #[test]
+    fn identifier_with_spaces_and_special_chars() {
+        assert_eq!(
+            quote_identifier("some table; DROP TABLE--"),
+            r#""some table; DROP TABLE--""#
+        );
+    }
+}

--- a/swanlake-core/src/util.rs
+++ b/swanlake-core/src/util.rs
@@ -15,6 +15,24 @@ pub fn quote_identifier(name: &str) -> String {
     format!(r#""{escaped}""#)
 }
 
+/// Quotes a potentially dot-separated qualified name (e.g. `schema.table`)
+/// by quoting each component independently so the dot is interpreted as a
+/// schema/catalog separator rather than part of the identifier.
+///
+/// # Examples
+///
+/// ```
+/// # use swanlake_core::util::quote_qualified_name;
+/// assert_eq!(quote_qualified_name("swanlake.my_table"), r#""swanlake"."my_table""#);
+/// assert_eq!(quote_qualified_name("plain"), r#""plain""#);
+/// ```
+pub fn quote_qualified_name(name: &str) -> String {
+    name.split('.')
+        .map(|part| quote_identifier(part))
+        .collect::<Vec<_>>()
+        .join(".")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -39,6 +57,27 @@ mod tests {
         assert_eq!(
             quote_identifier("some table; DROP TABLE--"),
             r#""some table; DROP TABLE--""#
+        );
+    }
+
+    #[test]
+    fn qualified_name_schema_table() {
+        assert_eq!(
+            quote_qualified_name("swanlake.my_table"),
+            r#""swanlake"."my_table""#
+        );
+    }
+
+    #[test]
+    fn qualified_name_single_part() {
+        assert_eq!(quote_qualified_name("users"), r#""users""#);
+    }
+
+    #[test]
+    fn qualified_name_three_parts() {
+        assert_eq!(
+            quote_qualified_name("catalog.schema.table"),
+            r#""catalog"."schema"."table""#
         );
     }
 }

--- a/tests/runner/src/scenarios/concurrent_sessions.rs
+++ b/tests/runner/src/scenarios/concurrent_sessions.rs
@@ -1,0 +1,45 @@
+use anyhow::{Context, Result};
+use swanlake_client::FlightSQLClient;
+use tracing::info;
+
+use crate::CliArgs;
+
+/// Concurrent session creation test (TOCTOU fix, issue #129)
+///
+/// Spawns multiple threads that each open a connection and execute `SELECT 1`
+/// concurrently, verifying that the session registry handles parallel creation
+/// without race conditions.
+pub fn run_concurrent_sessions(args: &CliArgs) -> Result<()> {
+    info!("Running concurrent session creation tests");
+
+    let num_threads = 10;
+    let endpoint = args.endpoint.clone();
+
+    let handles: Vec<_> = (0..num_threads)
+        .map(|i| {
+            let ep = endpoint.clone();
+            std::thread::spawn(move || -> Result<()> {
+                let mut client = FlightSQLClient::connect(&ep)
+                    .with_context(|| format!("thread {i}: failed to connect"))?;
+                let result = client.execute("SELECT 1")?;
+                anyhow::ensure!(
+                    result.total_rows == 1,
+                    "thread {i}: expected 1 row from SELECT 1, got {}",
+                    result.total_rows
+                );
+                info!("thread {i}: connected and queried successfully");
+                Ok(())
+            })
+        })
+        .collect();
+
+    for (i, handle) in handles.into_iter().enumerate() {
+        handle
+            .join()
+            .map_err(|_| anyhow::anyhow!("thread {i} panicked"))?
+            .with_context(|| format!("thread {i} returned an error"))?;
+    }
+
+    info!("Concurrent session creation tests completed successfully ({num_threads} threads)");
+    Ok(())
+}

--- a/tests/runner/src/scenarios/mod.rs
+++ b/tests/runner/src/scenarios/mod.rs
@@ -2,6 +2,7 @@ use crate::CliArgs;
 use anyhow::Result;
 
 pub mod appender_insert;
+pub mod concurrent_sessions;
 pub mod execute_query_commands;
 pub mod metadata_discovery;
 pub mod parameter_types;
@@ -15,5 +16,6 @@ pub fn run_all(args: &CliArgs) -> Result<()> {
     appender_insert::run(args)?;
     metadata_discovery::run_metadata_discovery(args)?;
     transaction_recovery::run_transaction_recovery(args)?;
+    concurrent_sessions::run_concurrent_sessions(args)?;
     Ok(())
 }

--- a/tests/sql/sql_injection_identifiers.test
+++ b/tests/sql/sql_injection_identifiers.test
@@ -1,0 +1,36 @@
+# name: tests/sql/sql_injection_identifiers.test
+# description: verify identifiers with special characters (quotes, semicolons, SQL keywords) are handled safely
+# group: [sql]
+
+# table name containing a literal double quote
+statement ok
+CREATE TABLE "test""injection" (id INT, val TEXT)
+
+statement ok
+INSERT INTO "test""injection" VALUES (1, 'hello'), (2, 'world')
+
+query IT
+SELECT id, val FROM "test""injection" ORDER BY id
+----
+1	hello
+2	world
+
+# table with special characters in column names
+statement ok
+CREATE TABLE injection_cols ("col;drop" INT, "col -- comment" TEXT)
+
+statement ok
+INSERT INTO injection_cols ("col;drop", "col -- comment") VALUES (42, 'safe'), (99, 'also safe')
+
+query IT
+SELECT "col;drop", "col -- comment" FROM injection_cols ORDER BY "col;drop"
+----
+42	safe
+99	also safe
+
+# cleanup
+statement ok
+DROP TABLE "test""injection"
+
+statement ok
+DROP TABLE injection_cols


### PR DESCRIPTION
## Summary

Fixes four critical bugs reported in the issue tracker.

### #126 — SQL Injection via Unescaped Identifiers (Security)
Added `quote_identifier()` helper in new `swanlake-core/src/util.rs` that wraps SQL identifiers in double quotes and escapes embedded quotes. Applied at all three interpolation sites:
- `engine/connection.rs`: `USE {catalog_name}` and `DESC SELECT * FROM {table_name}`
- `maintenance/mod.rs`: `USE {db}; CHECKPOINT`

### #127 — Ephemeral Prepared Statement Handle Leak
Added `remove_prepared_statement()` method on `Session` that unconditionally removes a handle from the map. Both call sites in `execute.rs` now force-remove the handle when `close_prepared_statement` fails, preventing unbounded memory growth.

### #128 — Session Transaction Inconsistency on Rollback Failure
On `ROLLBACK` failure, the Rust-side transaction tracking (`transactions` and `aborted_transactions`) is now cleared regardless, with an `error!`-level log. Prevents sessions from becoming permanently stuck.

### #129 — TOCTOU Race in Session Creation
Added a second existence check after acquiring the semaphore permit but before creating the expensive DuckDB connection. If another thread already created the session, the existing one is returned immediately — no wasted connection.

## Tests Added
- `tests/sql/sql_injection_identifiers.test` — end-to-end test with embedded quotes, semicolons, and SQL comment syntax in identifiers
- `tests/runner/src/scenarios/concurrent_sessions.rs` — 10-thread concurrent session creation scenario
- Unit tests for `quote_identifier` in `swanlake-core/src/util.rs`

Closes #126, closes #127, closes #128, closes #129