### PR TITLE
fix: change default database context from 'swanlake' to 'main'

### DIFF
--- a/examples/python-marimo/swanlake.py
+++ b/examples/python-marimo/swanlake.py
@@ -33,7 +33,7 @@ def _(conn, mo):
 def _(conn, mo):
     _df = mo.sql(
         f"""
-        use swanlake;
+        use main;
         """,
         engine=conn
     )


### PR DESCRIPTION
The example at `examples/python-marimo/swanlake.py` contains a cell with:

```sql
use swanlake;
```

This database does not exist by default in a fresh SwanLake instance. The default database available on connection is `main`. Running this example out of the box fails with a database-not-found error before any of the demo queries execute.